### PR TITLE
Update Compose v1 to Compose v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Run ETL jobs, train models, deploy models, and track model performance all from 
 2. Download the private key for the service account
     * Put it anywhere on your computer
     * Set the GOOGLE_APPLICATION_CREDENTIALS to point to it. `export GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/model-training-credentials.json`
-3. docker and docker-compose installed
+3. docker and docker compose v2 installed
     * https://docs.docker.com/compose/install/
-    * https://docs.docker.com/get-docker/ (not required for mac since docker and docker-compose are available together in the first link).
+    * https://docs.docker.com/get-docker/ (not required for mac since docker and docker compose v2 are available together in the first link).
 4. gcloud cli installed (and configured for the proper service account)
     * Run `curl https://sdk.cloud.google.com | bash` to install
     * `source ~/.<bash_profile/zshrc/bashrc>` to load env vars
@@ -79,7 +79,7 @@ Deploy the coordinator service on port 80
 
 * Updating containerized jobs
     - The training pipeline always uses the latest images. This means that anytime you build and push, the coordinator will use the pushed code automatically. <b>Do not push containers to GCR for a deployment that is being used in production unless you want those changes to be used</b>/.
-    - Update your code locally, run `docker-compose build <container_name>`, and then `docker-compose push <container_name>`.
+    - Update your code locally, run `docker compose build <container_name>`, and then `docker compose push <container_name>`.
 
 
 
@@ -133,7 +133,7 @@ Key terms:
 ### HTTPS
 
 * By default, the service uses http. To support https, you must have a domain name and an SSL certificate from a certificate authority. Once you have the certificate you can either directly update the service to use https or configure a reverse proxy with https. To update the service to use https, simply provide the ssl_keyfile and ssl_certfile params to app.run() at the bottom of coordinator.py. 
- If you directly update the server to use https you might want to change the default port to 443. You can change this in app.run(), the deployment script (update the firewall), and docker-compose (for local usage)
+ If you directly update the server to use https you might want to change the default port to 443. You can change this in app.run(), the deployment script (update the firewall), and docker compose (for local usage)
 
 
 ### M1 Mac

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -49,11 +49,11 @@ enable_service secretmanager.googleapis.com
 enable_service storage.googleapis.com
 
 # Build Containers
-docker-compose build
-docker-compose push
+docker compose build
+docker compose push
 
 # Configure storage and secrets
-docker-compose run deployment_config
+docker compose run deployment_config
 
 # Create Ingress
 gcloud compute firewall-rules create $FIREWALL_NAME \

--- a/deployment/reload_coordinator.sh
+++ b/deployment/reload_coordinator.sh
@@ -9,8 +9,8 @@ read -p "Do you want to proceed? (y/N)" -n 1 -r
 
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-    docker-compose build coordinator
-    docker-compose push coordinator
+    docker compose build coordinator
+    docker compose push coordinator
     gcloud compute instances stop $DEPLOYMENT_NAME
     gcloud compute instances start $DEPLOYMENT_NAME
 

--- a/deployment/reload_secrets.sh
+++ b/deployment/reload_secrets.sh
@@ -13,7 +13,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]
 then
     gcloud -q secrets delete ${DEPLOYMENT_NAME}_service_secret
     gcloud -q secrets delete ${DEPLOYMENT_NAME}_labelbox_api_key
-    docker-compose run deployment_config
+    docker compose run deployment_config
     gcloud -q compute instances stop --zone=us-central1-a $DEPLOYMENT_NAME
     gcloud -q compute instances start --zone=us-central1-a $DEPLOYMENT_NAME
     DEPLOYMENT_IP=$(gcloud compute instances describe $DEPLOYMENT_NAME --format='get(networkInterfaces[0].accessConfigs[0].natIP)')

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 set -e
 
-docker-compose build
-docker-compose push
-docker-compose up deployment_config
-docker-compose up -d coordinator
-docker-compose logs --follow coordinator
+docker compose build
+docker compose push
+docker compose up deployment_config
+docker compose up -d coordinator
+docker compose logs --follow coordinator


### PR DESCRIPTION
Since it won't be available in releases of Docker Desktop after June 23:

https://docs.docker.com/compose/migrate/

Changing from `docker-compose` to `docker compose` seems to work properly but you can double check the doc if you need any additional changes